### PR TITLE
Id duplication

### DIFF
--- a/server/src/modules/chat/repository/Repository.ts
+++ b/server/src/modules/chat/repository/Repository.ts
@@ -1,6 +1,10 @@
 export abstract class Repository <T> {
     protected values: T[] = []
 
+    protected getLast(): T | null | undefined {
+        return this.values[this.values.length - 1]
+    }
+    
     //Binary search algorithm to get the index of the item fast in huge arrays
     protected getIndex(id: number, filter: (value: T) => any): number {
         let low = 0

--- a/server/src/modules/chat/repository/Repository.ts
+++ b/server/src/modules/chat/repository/Repository.ts
@@ -1,3 +1,6 @@
+import { inspect } from "util"
+import { logger } from "../../../logger"
+
 export abstract class Repository <T> {
     protected values: T[] = []
 
@@ -8,7 +11,7 @@ export abstract class Repository <T> {
     //Binary search algorithm to get the index of the item fast in huge arrays
     protected getIndex(id: number, filter: (value: T) => any): number {
         let low = 0
-        let high = this.values.length
+        let high = (this.values.length - 1)
 
         while(low <= high) {
             const guessIndex = Math.round((low + high) / 2)

--- a/server/src/modules/chat/repository/UserRepository.ts
+++ b/server/src/modules/chat/repository/UserRepository.ts
@@ -1,6 +1,8 @@
 import User from "../model/User"
 import { Result } from "../../../lib/result"
 import { Repository } from "./Repository"
+import { logger } from "../../../logger"
+import { inspect } from "util"
 
 export interface UserRepository {
     save(socketId: string): Result<User>
@@ -11,26 +13,28 @@ export interface UserRepository {
 export default class UserRepositoryImpl extends Repository<User> implements UserRepository {
     public save(socketId: string): Result<User> {
         const previousUser = this.getLast()
-
+        
         const user: User = {
             id: previousUser ? previousUser.id + 1 : 0,
             socketId,
         }
-    
+        
         this.values.push(user)
+        logger.debug(`Length of the array is: ${this.values.length} and the array is ${inspect(this.values)}`)
 
         return { data: user }
  
     }
 
     public deleteUser(id: number): Result<number> {
-        const user = this.values[id - 1]
-
+        const index = this.getIndex(id, (user) => user.id)
+        const user = this.values[index]
+        
         if (!user) {
             return { error: "invalid_id" }
         }
 
-        this.values.splice(id, 1)
+        this.values.splice(index, 1)
 
         return { data: id }
     }

--- a/server/src/modules/chat/repository/UserRepository.ts
+++ b/server/src/modules/chat/repository/UserRepository.ts
@@ -10,8 +10,10 @@ export interface UserRepository {
 
 export default class UserRepositoryImpl extends Repository<User> implements UserRepository {
     public save(socketId: string): Result<User> {
+        const previousUser = this.getLast()
+
         const user: User = {
-            id: this.values.length,
+            id: previousUser ? previousUser.id + 1 : 0,
             socketId,
         }
     


### PR DESCRIPTION
- Fixed the id generation of users in the application, that problem used to occur when there was more than two clients connected to the server. Once the id was generated based on the length of the array and not the last user saved, sometimes the fetching of the users fail or the disconnected users weren't deleted from the memory. 
- Due to this problem, i changed how the id was generated, now the repository checks the last user saved, so the id will always be in order (1,2,3,4,5,6). I also fixed the binary search algorithm, i don't know why but i didn't put -1 when checking the high guess parameter, so as the <Array>.length starts to count on number 1, there was a bug that if the item was in the last position of the array, the value of the guess was null.
